### PR TITLE
Add cryo-EM density renderer

### DIFF
--- a/scripts/render_cryoem.py
+++ b/scripts/render_cryoem.py
@@ -1,0 +1,19 @@
+import torch
+from src.models.cryo_renderer import CryoEMRenderer
+from src.models.fields import DensityNetwork
+
+# Example usage of CryoEMRenderer
+if __name__ == "__main__":
+    density_net = DensityNetwork(checkpoint_path=None, style_dim=128, W=128, D=4, input_ch=3, input_ch_views=3)
+    renderer = CryoEMRenderer(density_network=density_net, n_samples=64, perturb=0.0)
+
+    # simple test rays
+    rays_o = torch.zeros(1, 3)
+    rays_d = torch.tensor([[0.0, 0.0, -1.0]])
+    near = torch.tensor([0.0])
+    far = torch.tensor([2.0])
+
+    z = torch.randn(1, 128)
+
+    out = renderer.render(rays_o, rays_d, near, far, z=z)
+    print('density_map', out['density_map'].shape)

--- a/src/models/cryo_renderer.py
+++ b/src/models/cryo_renderer.py
@@ -1,0 +1,43 @@
+import torch
+import torch.nn as nn
+
+class CryoEMRenderer:
+    """Renderer that integrates densities along camera rays to simulate cryo-EM projections."""
+
+    def __init__(self, density_network: nn.Module, n_samples: int = 64, perturb: float = 0.0):
+        self.density_network = density_network
+        self.n_samples = n_samples
+        self.perturb = perturb
+
+    def render(self, rays_o, rays_d, near, far, z=None, w=None, **_):
+        batch_size = rays_o.shape[0]
+        device = rays_o.device
+
+        z_vals = torch.linspace(0.0, 1.0, self.n_samples, device=device)
+        z_vals = near + (far - near) * z_vals[None, :]
+
+        if self.perturb > 0:
+            mids = 0.5 * (z_vals[..., 1:] + z_vals[..., :-1])
+            upper = torch.cat([mids, z_vals[..., -1:]], -1)
+            lower = torch.cat([z_vals[..., :1], mids], -1)
+            t_rand = torch.rand([batch_size, self.n_samples], device=device)
+            z_vals = lower + (upper - lower) * t_rand
+
+        pts = rays_o[:, None, :] + rays_d[:, None, :] * z_vals[..., :, None]
+        if z is not None or w is not None:
+            density = self.density_network(pts.reshape(-1, 3), z=z, w=w)[:, :1]
+        else:
+            density = self.density_network(pts.reshape(-1, 3))[:, :1]
+        density = density.reshape(batch_size, self.n_samples)
+
+        dists = z_vals[..., 1:] - z_vals[..., :-1]
+        dists = torch.cat([dists, dists[..., -1:]], -1)
+
+        weights = density * dists
+        projection = torch.sum(weights, dim=-1, keepdim=True)
+
+        return {
+            'density_map': projection,
+            'weights': weights,
+            'z_vals': z_vals,
+        }

--- a/src/models/fields.py
+++ b/src/models/fields.py
@@ -101,6 +101,59 @@ class ColorNetwork(nn.Module):
         return rgb
 
 
+class DensityNetwork(nn.Module):
+    """Simple MLP that outputs density values for cryo-EM volume rendering."""
+
+    def __init__(self, checkpoint_path=None, **kwargs):
+        super().__init__()
+
+        layers = []
+        for _ in range(3):
+            layers.append(
+                MappingLinear(kwargs['style_dim'], kwargs['style_dim'], activation="fused_lrelu")
+            )
+        self.style = nn.Sequential(*layers)
+        network = SirenGenerator(**kwargs)
+        self.pts_linears = network.pts_linears
+        self.density_linear = network.sigma_linear
+
+        if checkpoint_path is not None:
+            if dist.is_initialized():
+                device = f"cuda:{dist.get_rank()}"
+                self.to(device)
+            else:
+                device = "cuda"
+            state_dict = torch.load(checkpoint_path, map_location=device)
+            check_cfg_consistency(
+                kwargs,
+                state_dict['cfg']['model']['generator']['kwargs']['sdf_network']['kwargs'],
+                ignore_keys=['checkpoint_path'],
+            )
+            # Load weights into matching attributes
+            self.load_state_dict({k.replace('sigma_linear', 'density_linear'): v for k, v in state_dict['sdf_network'].items()})
+
+    def forward(self, x, z, w=None):
+        ray_bs = x.shape[0]
+        if w is not None:
+            bs = w.shape[0]
+        else:
+            bs = z.shape[0]
+        x = x.reshape(bs, ray_bs // bs, 1, 1, *x.shape[1:])
+
+        latent = self.style(z) if w is None else w
+
+        mlp_out = x.contiguous()
+        for layer in self.pts_linears:
+            mlp_out = layer(mlp_out, latent)
+
+        density = self.density_linear(mlp_out)
+        outputs = torch.cat([density, mlp_out], -1)
+        return outputs.flatten(0, 3)
+
+    def density(self, x, z, w=None):
+        return self.forward(x, z=z, w=w)[:, :1]
+
+
 def gradient(x, fn, second_order=False, laplacian=False):
     has_grad_outer = torch.is_grad_enabled()
     x.requires_grad_(True)


### PR DESCRIPTION
## Summary
- implement `DensityNetwork` to produce density values instead of SDF
- add `CryoEMRenderer` for integrating density along rays
- provide `render_cryoem.py` example script

## Testing
- `pytest -q` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688460fa71208331ac05bc4ce664d0c9